### PR TITLE
Added sync argument to Project constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ function runCopy(srcFolder, glob, destFolder, emitter, processPath, done){
 			var fileSrc = path.join(srcFolder, file)
 			var fileDest = path.join(destFolder, processPath(file))
 
-			cpFile(fileSrc, fileDest, nextFile)
+			if(this._sync){
+				cpFile.sync(fileSrc, fileDest);
+				nextFile();
+			}else{
+				cpFile.sync(fileSrc, fileDest, nextFile);
+			}
 
 		}, done)
 
@@ -41,11 +46,12 @@ function runCopy(srcFolder, glob, destFolder, emitter, processPath, done){
 }
 		
 
-function Project(src, dest){
-	if (!(this instanceof Project)) return new Project(src, dest)
+function Project(src, dest, sync){
+	if (!(this instanceof Project)) return new Project(src, dest, sync), 
 	EventEmitter.call(this)
 	this._src = src
 	this._dest = dest
+	this._sync = sync
 }
 
 Project.series = async.series


### PR DESCRIPTION
In OSX, the `ulimit` is hard-set by the OS, which maxes at 1024. This is the allowed number of open file descriptors at any one time. This can be reached fairly quickly on a project with many assets. Build scripts that use this library to copy many files, fail as a result. Adding a synchronous flag allows us to mitigate the issue in OSX platforms by passing a test for OSX as a third argument to Guilder:

`var project = Guilder(srcFolder, destFolder, /darwin/.test(process.platform))`

In a nutshell, this fixes copying issues in OSX by making the `runCopy` method synchronous when needed.
